### PR TITLE
Fixing file add in FF properly, Fixing 500s when adding, then removing files that aren't saved yet

### DIFF
--- a/core/static/js/attachments.js
+++ b/core/static/js/attachments.js
@@ -42,8 +42,16 @@
     };
 
     fileHandler.prototype.removeFile = function(index){
-      this.stack.splice(index,1);
-      this.input.files = ArraytoFileList(this.stack);
+      var sf = this.stack.slice(index, index+1)[0];
+      this.stack = this.stack.filter(function (i) {
+        return i !== sf;
+      });
+
+      var files = Array.from(this.input.files).filter(function (f) {
+        return !(sf.name === f.name && sf.size === f.size && sf.lastModified === f.lastModified);
+      });
+
+      this.input.files = ArraytoFileList(files);
 
       if(typeof this.onRemove !== 'undefined' && typeof this.onRemove === 'function'){
         this.onRemove(this.stack);
@@ -52,7 +60,7 @@
 
     fileHandler.prototype.clear = function(){
       this.stack = [];
-      this.input.files = ArraytoFileList(this.stack);
+      this.input.files = ArraytoFileList([]);
     };
 
     fileHandler.prototype.parse = function(filesRaw){
@@ -61,7 +69,7 @@
 
       var files = filesRaw.filter(function (f) {
         var match = this.stack.find(function (sf) {
-          return sf.name === f.name && sf.size === f.size && sf.lastModified === f.lastModified
+          return sf.name === f.name && sf.size === f.size && sf.lastModified === f.lastModified;
         });
 
         return !match;

--- a/core/static/js/simpleEditor.js
+++ b/core/static/js/simpleEditor.js
@@ -262,7 +262,6 @@
 
       if (delete_confirm){
         if (fileToBeRemoved.length > 0){
-
           if (typeof this.attachments_delete == 'undefined'){
             this.attachments_delete = [];
           }
@@ -274,14 +273,19 @@
             this.form.append(field_attachments_delete);
           }
 
-          if (this.attachments_delete.indexOf(fileToBeRemoved.attr('data-rel')) === -1){
+          var isSavedFile = !!fileToBeRemoved.attr('src').match(/(http|https)\:\/\//);
+          var notAlreadyDeleted = this.attachments_delete.indexOf(fileToBeRemoved.attr('data-rel')) === -1;
+
+          if (isSavedFile && notAlreadyDeleted) {
             this.attachments_delete.push(fileToBeRemoved.attr('data-rel'));
             field_attachments_delete.val(this.attachments_delete.join(','));
+          } else {
+            this.fileHandler.removeFile(self.index());
           }
-
-        }else{
+        } else {
           this.fileHandler.removeFile(self.index());
         }
+
         parent.remove();
       }
 


### PR DESCRIPTION
This time a bit more thorough, and debugged by local proxing in charles.

- Fixing crucial mistake (Line 7)
- De-duplication of added files, by comparing attributes and preventing double adding
- Adding, then removing files caused 500 errors because it wrongly added to the delete list hidden element. Prevented this.